### PR TITLE
Attempting a workaround for the databse is_connected proc returning false positive

### DIFF
--- a/code/orphaned_procs/dbcore.dm
+++ b/code/orphaned_procs/dbcore.dm
@@ -102,7 +102,11 @@ DBQuery/proc/Connect(DBConnection/connection_handler) src.db_connection = connec
 
 DBQuery/proc/Execute(sql_query=src.sql,cursor_handler=default_cursor)
 	Close()
-	return _dm_db_execute(_db_query,sql_query,db_connection._db_con,cursor_handler,null)
+	. = _dm_db_execute(_db_query,sql_query,db_connection._db_con,cursor_handler,null)
+	if(!.)	//No connection try to reconnect
+		setup_database_connection()
+		. = _dm_db_execute(_db_query,sql_query,db_connection._db_con,cursor_handler,null)
+	return
 
 DBQuery/proc/NextRow() return _dm_db_next_row(_db_query,item,conversions)
 


### PR DESCRIPTION
:cl: DantonDB tweaking
tweak: Danton DB quarry now does a connection check before excecuting.
/:cl: